### PR TITLE
Fix THREE.FirstPersonControls and THREE.OrbitControls definition.

### DIFF
--- a/threejs/three-FirstPersonControls.d.ts
+++ b/threejs/three-FirstPersonControls.d.ts
@@ -11,6 +11,7 @@ declare namespace THREE {
         object: THREE.Object3D;
         target: THREE.Vector3;
         domElement: HTMLCanvasElement;
+        enabled: boolean;
         movementSpeed: number;
         lookSpeed: number;
         noFly: boolean;
@@ -18,14 +19,13 @@ declare namespace THREE {
         autoForward: boolean;
         activeLook: boolean;
         heightSpeed: boolean;
-        heightCoef: boolean;
-        heightMin: boolean;
+        heightCoef: number;
+        heightMin: number;
+        heightMax: number;
         constrainVertical: boolean;
         verticalMin: number;
         verticalMax: number;
         autoSpeedFactor: number;
-        mouseX: number;
-        mouseY: number;
         lat: number;
         lon: number;
         phi: number;
@@ -37,5 +37,6 @@ declare namespace THREE {
         freeze: boolean;
         mouseDragOn: boolean;
         update(delta?: number): void;
+        dispose(): void;
     }
 }

--- a/threejs/three-orbitcontrols.d.ts
+++ b/threejs/three-orbitcontrols.d.ts
@@ -49,6 +49,7 @@ declare namespace THREE {
         dollyOut(dollyScale: number): void;
         update(): void;
         reset(): void;
+        dispose(): void;
         getPolarAngle(): number;
         getAzimuthalAngle(): number;
 


### PR DESCRIPTION
Based on THREE.js v78 examples folder.
1) Add missing `.enabled` and `.dispose()`
2) Correct `.height**` properties.
3) Remove `.mouseX` and `.mouseY` as I think it is for internal use only.